### PR TITLE
[W-20976280] fix help.salesforce.com links

### DIFF
--- a/modules/ROOT/pages/collaborating-with-your-api-portal-community.adoc
+++ b/modules/ROOT/pages/collaborating-with-your-api-portal-community.adoc
@@ -21,9 +21,9 @@ To see feedback and discussions about an API:
 
 For more information about using Chatter Feed tracking, see the following Salesforce documentation:
 
-* https://help.salesforce.com/s/articleView?id=sf.collab_overview.htm&type=5[Chatter Overview]
-* https://help.salesforce.com/s/articleView?id=sf.collab_home_overview.htm&type=5[Chatter Tab Overview]
-* https://help.salesforce.com/s/articleView?id=sf.collab_feed_posting.htm&type=5[Posting Overview]
+* https://help.salesforce.com/s/articleView?id=experience.collab_overview.htm&type=5[Chatter Overview]
+* https://help.salesforce.com/s/articleView?id=experience.collab_home_overview.htm&type=5[Chatter Tab Overview]
+* https://help.salesforce.com/s/articleView?id=experience.collab_feed_posting.htm&type=5[Posting Overview]
 * https://help.salesforce.com/s/articleView?id=sf.collab_feeds_parent.htm&type=5[Work with Feeds]
 
 

--- a/modules/ROOT/pages/look-and-feel-customization.adoc
+++ b/modules/ROOT/pages/look-and-feel-customization.adoc
@@ -21,7 +21,7 @@ The new page displays placeholders for content based on the layout.
 
 Fill in a new page by adding components from the Components menu, such as a Headline component in the page header, or an API Experience Hub component such as an API Version Carousel.
 
-The Pages list shows the editable configuration properties for each page, which are described in https://help.salesforce.com/s/articleView?id=sf.community_builder_manage_pages_overview.htm&type=5[Manage Your Community’s Pages and Their Properties in Experience Builder].
+The Pages list shows the editable configuration properties for each page, which are described in https://help.salesforce.com/s/articleView?id=experience.community_builder_manage_pages_overview.htm&type=5[Manage Your Community’s Pages and Their Properties in Experience Builder].
 
 == Components
 Clicking the Components lightning bolt icon displays the component palette, which includes Salesforce Experience Cloud components, such as Headline or Featured Topics, and components specific to API Experience Hub, such as API Carousel or API Console. You can drag any component from the component palette to the current page. Select the component on the page to show the component’s configuration options.
@@ -36,7 +36,7 @@ API Experience Hub has the following Lightning components:
 * Search Box
 * Search Result
 
-Detailed component information is available from the page and the Salesforce Experience Cloud https://help.salesforce.com/s/articleView?id=sf.rss_component_reference_table.htm&type=5[Components] documentation. See xref:api-experience-hub-lightning-components.adoc[API Experience Hub Lightning Components] for a description of each component.
+Detailed component information is available from the page and the Salesforce Experience Cloud https://help.salesforce.com/s/articleView?id=experience.rss_component_reference_table.htm&type=5[Components] documentation. See xref:api-experience-hub-lightning-components.adoc[API Experience Hub Lightning Components] for a description of each component.
 
 == Theme
 Clicking the Theme paintbrush icon offers these general branding parameters:
@@ -53,7 +53,7 @@ Specifies the site’s fonts, which include a primary font and header fonts, and
 * Theme Settings
 +
 You can adjust community styling by editing the CSS rules. Next to the Theme title, click the Theme list, and click Edit CSS.
-Refer to https://help.salesforce.com/s/articleView?id=sf.community_builder_theme_customize.htm&type=5[Customize Your Experience Site Theme].
+Refer to https://help.salesforce.com/s/articleView?id=experience.community_builder_theme_customize.htm&type=5[Customize Your Experience Site Theme].
 +
 Brand multiple portals using branding sets. For more information, see https://help.salesforce.com/s/articleView?id=sf.community_designer_brandsets.htm&type=5[Use Branding Sets in Experience Builder].
 

--- a/modules/ROOT/pages/updating-expiring-certificates.adoc
+++ b/modules/ROOT/pages/updating-expiring-certificates.adoc
@@ -32,5 +32,5 @@ image::aeh-rename-cert.png["Example for renaming the certificate",width=60%]
 == See Also
 
 * xref:connecting-to-salesforce.adoc[]
-* https://help.salesforce.com/s/articleView?id=sf.named_credentials_about.htm&type=5[Named Credentials]
+* https://help.salesforce.com/s/articleView?id=xcloud.named_credentials_about.htm&type=5[Named Credentials]
 

--- a/modules/ROOT/pages/working-with-sandboxes.adoc
+++ b/modules/ROOT/pages/working-with-sandboxes.adoc
@@ -16,7 +16,7 @@ Manage Salesforce organizations from the *Manage your API portal* page by select
 .. Save your changes. 
 . Ensure that you have sandbox organizations already set up. 
 +
-For more information about creating sandboxes, see https://help.salesforce.com/s/articleView?id=sf.data_sandbox_create.htm&type=5[Create a Sandbox] in the Salesforce documentation.
+For more information about creating sandboxes, see https://help.salesforce.com/s/articleView?id=platform.data_sandbox_create.htm&type=5[Create a Sandbox] in the Salesforce documentation.
 
 [NOTE]
 Anypoint assets and applications aren't copied to sandbox or production organizations.


### PR DESCRIPTION
## Summary
Applied text replacement for Salesforce documentation URL updates in docs-api-experience-hub.

## Changes
- Replaced URLs in 4 file(s)

## Files Changed
- ./modules/ROOT/pages/collaborating-with-your-api-portal-community.adoc (multiple replacements)
- ./modules/ROOT/pages/look-and-feel-customization.adoc (multiple replacements)
- ./modules/ROOT/pages/updating-expiring-certificates.adoc
- ./modules/ROOT/pages/working-with-sandboxes.adoc

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] Update
- [ ] Refactor
- [ ] Documentation

## Related
- GUS Work Item: W-20976280