### PR TITLE
W-17618137 surround invalid URLs with `s

### DIFF
--- a/modules/ROOT/pages/configuring-sso.adoc
+++ b/modules/ROOT/pages/configuring-sso.adoc
@@ -186,7 +186,7 @@ Create a new application for the API Experience Hub portal in the identity provi
 |Field|Value
 |*Single Sign-On URL* |Enter the URL for the portal login.
 |*Use this for Recipient URL and Destination URL*|Select this option.
-|*Audience URI (SP Entity ID)* |Enter https with the Salesforce domain or example, `https://{salesforcedomain}.com`.
+|*Audience URI (SP Entity ID)* |Enter https with the Salesforce domain or example, `\https://{salesforcedomain}.com`.
 |*Name ID format* |*EmailAddress*
 |*Application username* |*Okta username*
 |*Update application username on* |*Create and update*
@@ -272,10 +272,10 @@ Create a new application for the API Experience Hub portal in the identity provi
 [%header,cols="1a,2a"]
 |===
 |Field|Value
-|Identifier (Entity ID)|`https://<YOUR_DOMAIN>.my.site.com/aeh`
-|Reply URL (Assertion Consumer Service URL)| `https://<YOUR_DOMAIN>.my.site.com/aeh/login`
-|Sign on URL |`https://<YOUR_DOMAIN>.my.site.com/aeh/login`
-|Logout Url (Optional)|`https://<YOUR_DOMAIN>.my.site.com/aeh/services/auth/sp/saml2/logout`
+|Identifier (Entity ID)|`\https://<YOUR_DOMAIN>.my.site.com/aeh`
+|Reply URL (Assertion Consumer Service URL)| `\https://<YOUR_DOMAIN>.my.site.com/aeh/login`
+|Sign on URL |`\https://<YOUR_DOMAIN>.my.site.com/aeh/login`
+|Logout Url (Optional)|`\https://<YOUR_DOMAIN>.my.site.com/aeh/services/auth/sp/saml2/logout`
 |===
 .. Save your changes.
 . Configure the required first name, last name, email, and username claims that the application sends:

--- a/modules/ROOT/pages/configuring-sso.adoc
+++ b/modules/ROOT/pages/configuring-sso.adoc
@@ -101,9 +101,9 @@ To configure the redirects, use your 15 digit organization ID and 18 digits org 
 .. In the Okta application, select the *General* tab.
 Add the following URLs for *Sign-in redirect URIs*:    
 +
-* https://login.salesforce.com/services/authcallback/${15DigitSalesforceOrganizationId}/${authProviderURLSuffix}
-* https://login.salesforce.com/services/authcallback/${18DigitSalesforceOrganizationId}/${authProviderURLSuffix}
-* https://${domain}.my.site.com/aeh/services/authcallback/${authProviderURLSuffix}
+* `https://login.salesforce.com/services/authcallback/${15DigitSalesforceOrganizationId}/${authProviderURLSuffix}`
+* `https://login.salesforce.com/services/authcallback/${18DigitSalesforceOrganizationId}/${authProviderURLSuffix}`
+* `https://${domain}.my.site.com/aeh/services/authcallback/${authProviderURLSuffix}`
 +
 image::aeh-sso-redirect-uris.png["An example of Redirect URIs",width=60%]
 To find the URLs:
@@ -186,7 +186,7 @@ Create a new application for the API Experience Hub portal in the identity provi
 |Field|Value
 |*Single Sign-On URL* |Enter the URL for the portal login.
 |*Use this for Recipient URL and Destination URL*|Select this option.
-|*Audience URI (SP Entity ID)* |Enter https with the Salesforce domain or example, https://{salesforcedomain}.com.
+|*Audience URI (SP Entity ID)* |Enter https with the Salesforce domain or example, `https://{salesforcedomain}.com`.
 |*Name ID format* |*EmailAddress*
 |*Application username* |*Okta username*
 |*Update application username on* |*Create and update*
@@ -272,10 +272,10 @@ Create a new application for the API Experience Hub portal in the identity provi
 [%header,cols="1a,2a"]
 |===
 |Field|Value
-|Identifier (Entity ID)|https://<YOUR_DOMAIN>.my.site.com/aeh
-|Reply URL (Assertion Consumer Service URL)| https://<YOUR_DOMAIN>.my.site.com/aeh/login
-|Sign on URL |https://<YOUR_DOMAIN>.my.site.com/aeh/login
-|Logout Url (Optional)|https://<YOUR_DOMAIN>.my.site.com/aeh/services/auth/sp/saml2/logout
+|Identifier (Entity ID)|`https://<YOUR_DOMAIN>.my.site.com/aeh`
+|Reply URL (Assertion Consumer Service URL)| `https://<YOUR_DOMAIN>.my.site.com/aeh/login`
+|Sign on URL |`https://<YOUR_DOMAIN>.my.site.com/aeh/login`
+|Logout Url (Optional)|`https://<YOUR_DOMAIN>.my.site.com/aeh/services/auth/sp/saml2/logout`
 |===
 .. Save your changes.
 . Configure the required first name, last name, email, and username claims that the application sends:

--- a/modules/ROOT/pages/configuring-sso.adoc
+++ b/modules/ROOT/pages/configuring-sso.adoc
@@ -101,9 +101,9 @@ To configure the redirects, use your 15 digit organization ID and 18 digits org 
 .. In the Okta application, select the *General* tab.
 Add the following URLs for *Sign-in redirect URIs*:    
 +
-* `https://login.salesforce.com/services/authcallback/${15DigitSalesforceOrganizationId}/${authProviderURLSuffix}`
-* `https://login.salesforce.com/services/authcallback/${18DigitSalesforceOrganizationId}/${authProviderURLSuffix}`
-* `https://${domain}.my.site.com/aeh/services/authcallback/${authProviderURLSuffix}`
+* `\https://login.salesforce.com/services/authcallback/${15DigitSalesforceOrganizationId}/${authProviderURLSuffix}`
+* `\https://login.salesforce.com/services/authcallback/${18DigitSalesforceOrganizationId}/${authProviderURLSuffix}`
+* `\https://${domain}.my.site.com/aeh/services/authcallback/${authProviderURLSuffix}`
 +
 image::aeh-sso-redirect-uris.png["An example of Redirect URIs",width=60%]
 To find the URLs:

--- a/modules/ROOT/pages/configuring-user-analytics.adoc
+++ b/modules/ROOT/pages/configuring-user-analytics.adoc
@@ -57,8 +57,8 @@ To configure Google Analytics to send events from the portal:
 ----
 . From *Setup*, click *Security & Privacy*.
 . Confirm that the following URLs show in the *Trusted Sites for Scripts* section:
-* https://www.google-analytics.com
-* https://www.googletagmanager.com
+* `https://www.google-analytics.com`
+* `https://www.googletagmanager.com`
 . If the URLs are missing, add them by clicking *Add Trusted Site*.
 . From *Setup*, click *Security* > *Trusted URLs*.
 . Confirm that the same two URLs are in the list of the *Trusted URLs* section.

--- a/modules/ROOT/pages/configuring-user-analytics.adoc
+++ b/modules/ROOT/pages/configuring-user-analytics.adoc
@@ -57,8 +57,8 @@ To configure Google Analytics to send events from the portal:
 ----
 . From *Setup*, click *Security & Privacy*.
 . Confirm that the following URLs show in the *Trusted Sites for Scripts* section:
-* `https://www.google-analytics.com`
-* `https://www.googletagmanager.com`
+* `\https://www.google-analytics.com`
+* `\https://www.googletagmanager.com`
 . If the URLs are missing, add them by clicking *Add Trusted Site*.
 . From *Setup*, click *Security* > *Trusted URLs*.
 . Confirm that the same two URLs are in the list of the *Trusted URLs* section.

--- a/modules/ROOT/pages/troubleshoot-sso-errors.adoc
+++ b/modules/ROOT/pages/troubleshoot-sso-errors.adoc
@@ -12,9 +12,9 @@ A 400 error occurs when logging in to the portal with SSO if the external identi
 
 To troubleshoot this issue, make sure to include necessary redirect URIs:
 
-* `https://login.salesforce.com/services/authcallback/${salesforceOrganizationId}/${authProviderURLSuffix`
-* `https://${domain}.my.salesforce.com/services/authcallback/${authProviderURLSuffix}`
-* `https://${domain}.my.site.com/aeh/services/authcallback/${authProviderURLSuffix}`
+* `\https://login.salesforce.com/services/authcallback/${salesforceOrganizationId}/${authProviderURLSuffix`
+* `\https://${domain}.my.salesforce.com/services/authcallback/${authProviderURLSuffix}`
+* `\https://${domain}.my.site.com/aeh/services/authcallback/${authProviderURLSuffix}`
 
 To get the following redirect URIs:
 

--- a/modules/ROOT/pages/troubleshoot-sso-errors.adoc
+++ b/modules/ROOT/pages/troubleshoot-sso-errors.adoc
@@ -12,9 +12,9 @@ A 400 error occurs when logging in to the portal with SSO if the external identi
 
 To troubleshoot this issue, make sure to include necessary redirect URIs:
 
-* https://login.salesforce.com/services/authcallback/${salesforceOrganizationId}/${authProviderURLSuffix}
-* https://${domain}.my.salesforce.com/services/authcallback/${authProviderURLSuffix}
-* https://${domain}.my.site.com/aeh/services/authcallback/${authProviderURLSuffix}
+* `https://login.salesforce.com/services/authcallback/${salesforceOrganizationId}/${authProviderURLSuffix`
+* `https://${domain}.my.salesforce.com/services/authcallback/${authProviderURLSuffix}`
+* `https://${domain}.my.site.com/aeh/services/authcallback/${authProviderURLSuffix}`
 
 To get the following redirect URIs:
 


### PR DESCRIPTION
these URLs are used for examples or configurations, but if they are not surrounded with `s, then users can click them.